### PR TITLE
Add CheckForUpdates toggle

### DIFF
--- a/Code 3 Callouts/Code 3 Callouts/Code 3 Callouts.ini
+++ b/Code 3 Callouts/Code 3 Callouts/Code 3 Callouts.ini
@@ -4,6 +4,9 @@
 // For use by beta testers only -- if this is a beta version, add your beta authorization key below
 BetaKey=NULL
 
+// Set to False to disable checking for script updates on load
+CheckForUpdates=True
+
 // Set to True to play 1-Adam-12 easter egg intro
 PlayAdam12Intro=False
 

--- a/Code 3 Callouts/Code 3 Callouts/Common.cs
+++ b/Code 3 Callouts/Code 3 Callouts/Common.cs
@@ -205,7 +205,9 @@ namespace Stealth.Plugins.Code3Callouts
 
         internal static void CheckForUpdates()
         {
-            Stealth.Common.Functions.UpdateFuncs.CheckForUpdates(Constants.LCPDFRDownloadID, Common.Version, Common.VersionInfo.ProductName, true);
+            if (Config.CheckForUpdates == true) {
+                Stealth.Common.Functions.UpdateFuncs.CheckForUpdates(Constants.LCPDFRDownloadID, Common.Version, Common.VersionInfo.ProductName, true);
+            }
         }
 
         internal static bool PreloadChecks()

--- a/Code 3 Callouts/Code 3 Callouts/Config.cs
+++ b/Code 3 Callouts/Code 3 Callouts/Config.cs
@@ -17,6 +17,7 @@ namespace Stealth.Plugins.Code3Callouts
 
         internal static InitializationFile mINIFile = new InitializationFile(INIFilePath);
         internal static string BetaKey { get; set; } = "NULL";
+        internal static bool CheckForUpdates { get; set; }
         internal static bool PlayAdam12intro { get; set; }
         internal static DISPATCH.DIVISION UnitDivision { get; set; }
         internal static DISPATCH.UNIT_TYPE UnitType { get; set; }
@@ -69,6 +70,7 @@ namespace Stealth.Plugins.Code3Callouts
             mINIFile.Create();
 
             //Settings
+            mINIFile.Write(ECfgSections.SETTINGS.ToString(), ESettings.CheckForUpdates.ToString(), false);
             mINIFile.Write(ECfgSections.SETTINGS.ToString(), ESettings.PlayAdam12intro.ToString(), false);
             mINIFile.Write(ECfgSections.SETTINGS.ToString(), ESettings.UnitDivision.ToString(), DISPATCH.DIVISION.DIV_01.ToString());
             mINIFile.Write(ECfgSections.SETTINGS.ToString(), ESettings.UnitType.ToString(), DISPATCH.UNIT_TYPE.ADAM.ToString());
@@ -109,6 +111,7 @@ namespace Stealth.Plugins.Code3Callouts
             //Settings
             BetaKey = mINIFile.ReadString(ECfgSections.SETTINGS.ToString(), "BetaKey", "NULL");
 
+            CheckForUpdates = mINIFile.ReadBoolean(ECfgSections.SETTINGS.ToString(), ESettings.CheckForUpdates.ToString(), false);
             PlayAdam12intro = mINIFile.ReadBoolean(ECfgSections.SETTINGS.ToString(), ESettings.PlayAdam12intro.ToString(), false);
             UnitDivision = mINIFile.ReadEnum<DISPATCH.DIVISION>(ECfgSections.SETTINGS.ToString(), ESettings.UnitDivision.ToString(), DISPATCH.DIVISION.DIV_01);
             UnitType = mINIFile.ReadEnum<DISPATCH.UNIT_TYPE>(ECfgSections.SETTINGS.ToString(), ESettings.UnitType.ToString(), DISPATCH.UNIT_TYPE.ADAM);
@@ -194,6 +197,7 @@ namespace Stealth.Plugins.Code3Callouts
 
         private enum ESettings
         {
+            CheckForUpdates,
             PlayAdam12intro,
             UnitDivision,
             UnitType,


### PR DESCRIPTION
This commit was accidentally reverted through an improperly filed pull request. This adds a CheckForUpdates toggle to disable checking for script updates on load.